### PR TITLE
Disable email notifications from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "node"
   - "6"
+notifications:
+   email: false


### PR DESCRIPTION
Personally I find them quite annoying. Especially when using protected branches I don’t see how email notifications for build failures are useful.