### PR TITLE
Fix ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "extends": "holidaycheck/es2015",
+  "parserOptions": {
+    "sourceType": "script"
+  },
   "env": {
     "node": true
   }

--- a/lib/BabelPluginExportToFunction.js
+++ b/lib/BabelPluginExportToFunction.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const R = require('ramda');
 const babelTemplate = require('babel-template');
 

--- a/lib/auth0Bundler.js
+++ b/lib/auth0Bundler.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const R = require('ramda');
 const babelTransform = require('babel-core').transform;
 const rollup = require('rollup').rollup;

--- a/lib/buildLiteralAst.js
+++ b/lib/buildLiteralAst.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable no-use-before-define */
 
 const R = require('ramda');

--- a/lib/bundleScript.js
+++ b/lib/bundleScript.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function bundleRule(dependencies, injectedConfig, ruleFilename) {
     const { rollup, babelTransform, BabelPluginExportToFunction, buildLiteralAst, rollupCommonjs } = dependencies;
 

--- a/test/functional/fixtures/lib.js
+++ b/test/functional/fixtures/lib.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
     add: (a, b) => a + b,
     subtract: (a, b) => a - b

--- a/test/functional/fixtures/rule.js
+++ b/test/functional/fixtures/rule.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const R = require('ramda');
 const { add, subtract } = require('./lib');
 

--- a/test/functional/fixtures/script.js
+++ b/test/functional/fixtures/script.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { add } = require('./lib');
 
 module.exports = function toBeTested(config, number, callback) {

--- a/test/functional/functionalSpec.js
+++ b/test/functional/functionalSpec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ava = require('ava');
 const path = require('path');
 

--- a/test/unit/BabelPluginExportToFunctionSpec.js
+++ b/test/unit/BabelPluginExportToFunctionSpec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const test = require('ava').test;
 const babel = require('babel-core');
 const babelTypes = require('babel-types');

--- a/test/unit/buildLiteralAstSpec.js
+++ b/test/unit/buildLiteralAstSpec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const test = require('ava').test;
 const R = require('ramda');
 const babelTypes = require('babel-types');

--- a/test/unit/bundleScriptSpec.js
+++ b/test/unit/bundleScriptSpec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { test } = require('ava');
 const sinon = require('sinon');
 


### PR DESCRIPTION
The `holidaycheck/es2015` config sets the source type of files to `module` but in this project we actually use scripts.