### PR TITLE
Ignore external modules from being resolved

### DIFF
--- a/lib/bundleScript.js
+++ b/lib/bundleScript.js
@@ -1,11 +1,15 @@
 'use strict';
 
+function isExternalModule(moduleId) {
+    return !moduleId.startsWith('.');
+}
+
 module.exports = function bundleRule(dependencies, injectedConfig, ruleFilename) {
     const { rollup, babelTransform, BabelPluginExportToFunction, buildLiteralAst, rollupCommonjs } = dependencies;
 
     return Promise.resolve(rollup({
         entry: ruleFilename,
-        plugins: [ rollupCommonjs() ]
+        plugins: [ rollupCommonjs({ ignore: isExternalModule }) ]
     })).then((bundle) => {
         const optionsAst = buildLiteralAst(injectedConfig);
         const bundleCode = bundle.generate({ format: 'es' }).code;

--- a/test/functional/functionalSpec.js
+++ b/test/functional/functionalSpec.js
@@ -2,6 +2,8 @@
 
 const ava = require('ava');
 const path = require('path');
+const sinon = require('sinon');
+const Promise = require('bluebird');
 
 const { bundleRule, bundleScript } = require('../../lib/auth0Bundler');
 
@@ -34,3 +36,19 @@ ava.test('it should build a script that can be evaled (evil!)', (t) => {
     });
 });
 
+ava.test('doesn’t log warnings to the console', (t) => {
+    /* eslint-disable no-console */
+    sinon.stub(console, 'error');
+
+    t.plan(1);
+
+    const rulePath = path.join(__dirname, 'fixtures/rule.js');
+
+    return Promise.resolve(bundleRule({}, rulePath))
+        .then(() => {
+            t.is(console.error.callCount, 0);
+        })
+        .finally(() => {
+            console.error.restore();
+        });
+});


### PR DESCRIPTION
We don’t want to resolve modules from `node_modules` or from node.js core.
This also prevents rollup from logging warnings to the console.