### PR TITLE
Add eslint-plugin-node

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,13 @@
 {
-  "extends": "holidaycheck/es2015",
-  "parserOptions": {
-    "sourceType": "script"
-  },
-  "env": {
-    "node": true
-  }
+    "extends": "holidaycheck/es2015",
+    "plugins": [ "node" ],
+    "parserOptions": {
+        "sourceType": "script"
+    },
+    "env": {
+        "node": true
+    },
+    "rules": {
+        "node/no-unsupported-features": "error"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "auth0-bundler",
   "version": "1.0.2",
   "description": "Bundle rules, scripts and hooks to deploy them to Auth0.",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "main": "lib/auth0Bundler.js",
   "files": [
     "lib/",
@@ -32,6 +35,7 @@
     "ava": "0.25.0",
     "eslint": "4.19.1",
     "eslint-config-holidaycheck": "0.13.1",
+    "eslint-plugin-node": "^6.0.1",
     "sinon": "5.1.0",
     "vm2": "3.6.0"
   },


### PR DESCRIPTION
This checks that we don’t accidentally use language features that are not supported by the target node environments.