### PR TITLE
Use first supported node version as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.1 (September 2, 2020)
+
+### Bug fix
+
+* Fix default version of node passed `createBundle` function
+
 ## 1.3.0 (September 1, 2020)
 
 ### Changes

--- a/lib/auth0Bundler.js
+++ b/lib/auth0Bundler.js
@@ -13,7 +13,7 @@ const dependencies = { rollup, babelTransform, BabelPluginExportToFunction, buil
 
 const nodeVersionsSupportedByAuth0 = [ 8, 12 ];
 
-const defaultNodeVersion = 4;
+const defaultNodeVersion = nodeVersionsSupportedByAuth0[0];
 
 module.exports = function createBundler({ nodeVersion = defaultNodeVersion } = {}) {
     if (!nodeVersionsSupportedByAuth0.includes(nodeVersion)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-bundler",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Bundle rules, scripts and hooks to deploy them to Auth0.",
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
just to avoind issues with not supported default in the future