### PR TITLE
Added pluggable option to auth0-bundler.

### DIFF
--- a/lib/auth0Bundler.js
+++ b/lib/auth0Bundler.js
@@ -15,7 +15,7 @@ const nodeVersionsSupportedByAuth0 = [ 8, 12 ];
 
 const defaultNodeVersion = nodeVersionsSupportedByAuth0[0];
 
-module.exports = function createBundler({ nodeVersion = defaultNodeVersion } = {}) {
+module.exports = function createBundler({ nodeVersion = defaultNodeVersion, plugins = a => a } = {}) {
     if (!nodeVersionsSupportedByAuth0.includes(nodeVersion)) {
         const message = `Unsupported node version ${nodeVersion}, ` +
             `only one of the following versions are supported: ${nodeVersionsSupportedByAuth0.join(', ')}`;
@@ -24,9 +24,9 @@ module.exports = function createBundler({ nodeVersion = defaultNodeVersion } = {
     }
 
     return {
-        bundleScript: R.partial(bundle, [ dependencies, { commonjs: false, nodeVersion } ]),
-        bundleRule: R.partial(bundle, [ dependencies, { commonjs: false, nodeVersion } ]),
-        bundleHook: R.partial(bundle, [ dependencies, { commonjs: true, nodeVersion } ])
+        bundleScript: R.partial(bundle, [ dependencies, { commonjs: false, nodeVersion, plugins } ]),
+        bundleRule: R.partial(bundle, [ dependencies, { commonjs: false, nodeVersion, plugins } ]),
+        bundleHook: R.partial(bundle, [ dependencies, { commonjs: true, nodeVersion, plugins } ])
     };
 };
 

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -12,7 +12,7 @@ module.exports = function bundleRule(dependencies, options, injectedConfig, rule
 
     return Promise.resolve(rollup({
         input: ruleFilename,
-        plugins: [ rollupCommonjs({ ignore: isExternalModule }) ]
+        plugins: options.plugins([ rollupCommonjs({ ignore: isExternalModule }) ])
     })).then((bundle) => {
         const optionsAst = buildLiteralAst(injectedConfig);
         return bundle.generate({ format: 'es' }).then(({ output: [ { code } ] }) => {


### PR DESCRIPTION
Based on https://github.com/holidaycheck/auth0-bundler/issues/148

This allows us to add typescript to our Auth0 Rules via https://www.npmjs.com/package/rollup-plugin-typescript2, it should help others achieve similar results.